### PR TITLE
Fix diacritics in Firefox Developer Edition

### DIFF
--- a/static/css/style6.css
+++ b/static/css/style6.css
@@ -1,6 +1,72 @@
-@import url(https://fonts.googleapis.com/css?family=Amatic+SC:400,700&subset=latin,latin-ext);
+/* amatic-sc-regular - latin-ext_latin */
+@font-face {
+    font-family: 'Amatic SC';
+    font-style: normal;
+    font-weight: 400;
+    src: url('../fonts/amatic-sc-v9-latin-ext_latin-regular.eot'); /* IE9 Compat Modes */
+    src: local('Amatic SC Regular'), local('AmaticSC-Regular'),
+         url('../fonts/amatic-sc-v9-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+         url('../fonts/amatic-sc-v9-latin-ext_latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
+         url('../fonts/amatic-sc-v9-latin-ext_latin-regular.woff') format('woff'), /* Modern Browsers */
+         url('../fonts/amatic-sc-v9-latin-ext_latin-regular.ttf') format('truetype'), /* Safari, Android, iOS */
+         url('../fonts/amatic-sc-v9-latin-ext_latin-regular.svg#AmaticSC') format('svg'); /* Legacy iOS */
+    }
 
-@import url(https://fonts.googleapis.com/css?family=Oswald:400,300,700);
+/* amatic-sc-700 - latin-ext_latin */
+@font-face {
+  font-family: 'Amatic SC';
+  font-style: normal;
+  font-weight: 700;
+  src: url('../fonts/amatic-sc-v9-latin-ext_latin-700.eot'); /* IE9 Compat Modes */
+  src: local('Amatic SC Bold'), local('AmaticSC-Bold'),
+       url('../fonts/amatic-sc-v9-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('../fonts/amatic-sc-v9-latin-ext_latin-700.woff2') format('woff2'), /* Super Modern Browsers */
+       url('../fonts/amatic-sc-v9-latin-ext_latin-700.woff') format('woff'), /* Modern Browsers */
+       url('../fonts/amatic-sc-v9-latin-ext_latin-700.ttf') format('truetype'), /* Safari, Android, iOS */
+       url('../fonts/amatic-sc-v9-latin-ext_latin-700.svg#AmaticSC') format('svg'); /* Legacy iOS */
+}
+
+/* oswald-regular - latin-ext_latin */
+@font-face {
+  font-family: 'Oswald';
+  font-style: normal;
+  font-weight: 400;
+  src: url('../fonts/oswald-v11-latin-ext_latin-regular.eot'); /* IE9 Compat Modes */
+  src: local('Oswald Regular'), local('Oswald-Regular'),
+       url('../fonts/oswald-v11-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('../fonts/oswald-v11-latin-ext_latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
+       url('../fonts/oswald-v11-latin-ext_latin-regular.woff') format('woff'), /* Modern Browsers */
+       url('../fonts/oswald-v11-latin-ext_latin-regular.ttf') format('truetype'), /* Safari, Android, iOS */
+       url('../fonts/oswald-v11-latin-ext_latin-regular.svg#Oswald') format('svg'); /* Legacy iOS */
+}
+
+/* oswald-300 - latin-ext_latin */
+@font-face {
+  font-family: 'Oswald';
+  font-style: normal;
+  font-weight: 300;
+  src: url('../fonts/oswald-v11-latin-ext_latin-300.eot'); /* IE9 Compat Modes */
+  src: local('Oswald Light'), local('Oswald-Light'),
+       url('../fonts/oswald-v11-latin-ext_latin-300.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('../fonts/oswald-v11-latin-ext_latin-300.woff2') format('woff2'), /* Super Modern Browsers */
+       url('../fonts/oswald-v11-latin-ext_latin-300.woff') format('woff'), /* Modern Browsers */
+       url('../fonts/oswald-v11-latin-ext_latin-300.ttf') format('truetype'), /* Safari, Android, iOS */
+       url('../fonts/oswald-v11-latin-ext_latin-300.svg#Oswald') format('svg'); /* Legacy iOS */
+}
+
+/* oswald-700 - latin-ext_latin */
+@font-face {
+  font-family: 'Oswald';
+  font-style: normal;
+  font-weight: 700;
+  src: url('../fonts/oswald-v11-latin-ext_latin-700.eot'); /* IE9 Compat Modes */
+  src: local('Oswald Bold'), local('Oswald-Bold'),
+       url('../fonts/oswald-v11-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('../fonts/oswald-v11-latin-ext_latin-700.woff2') format('woff2'), /* Super Modern Browsers */
+       url('../fonts/oswald-v11-latin-ext_latin-700.woff') format('woff'), /* Modern Browsers */
+       url('../fonts/oswald-v11-latin-ext_latin-700.ttf') format('truetype'), /* Safari, Android, iOS */
+       url('../fonts/oswald-v11-latin-ext_latin-700.svg#Oswald') format('svg'); /* Legacy iOS */
+}
 
 html, body {
     margin: 0;


### PR DESCRIPTION
This PR replaces the font source from Google to local fonts. This fixes the issue with Firefox Developer Edition (the font sanitizer would reject the Google-loaded fonts for some reason or other).

Fixes #134